### PR TITLE
Add Codacy coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,33 @@
+name: Code Coverage
+
+on: [push, pull_request]
+
+jobs:
+  coverage:
+    name: Generate Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codacy
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: lcov.info


### PR DESCRIPTION
## Summary
- Adds new GitHub Actions workflow to generate and track code coverage
- Uses cargo-llvm-cov to generate coverage reports in lcov format
- Automatically uploads coverage to Codacy on push and pull requests

## Test plan
- [ ] Verify workflow runs successfully on push
- [ ] Ensure CODACY_PROJECT_TOKEN secret is configured in repository settings
- [ ] Confirm coverage data is uploaded to Codacy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added an automated code coverage workflow that runs on pushes and pull requests.
  - Generates comprehensive coverage reports across the project and uploads them to Codacy for centralized tracking.
  - Caches dependencies to accelerate CI runs and reduce execution time.
  - Enhances visibility of test coverage in PRs, supporting continuous quality monitoring and easier regressions detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->