### PR TITLE
Fix all clippy warnings and improve code quality

### DIFF
--- a/bsv/src/bitcoin/address.rs
+++ b/bsv/src/bitcoin/address.rs
@@ -58,10 +58,8 @@ mod tests {
 
     #[test]
     fn test_mainnet() {
-        let (pv, n) = PrivateKey::from_wif(
-            &"KwTeZVihYnMmcKP5MEfMeN1V726HNKFF84dWzEcqjyc7afgfyn5x".to_string(),
-        )
-        .expect("Failed to parse WIF private key for test");
+        let (pv, n) = PrivateKey::from_wif("KwTeZVihYnMmcKP5MEfMeN1V726HNKFF84dWzEcqjyc7afgfyn5x")
+            .expect("Failed to parse WIF private key for test");
         assert_eq!(n, KeyAddressKind::Main);
         let addr = Address::from_pv(&pv, n);
         assert_eq!(addr.kind, KeyAddressKind::Main);

--- a/bsv/src/bitcoin/base58ck.rs
+++ b/bsv/src/bitcoin/base58ck.rs
@@ -7,13 +7,12 @@ use base58::{FromBase58, ToBase58};
 /// Some Bitcoin standards use base-58 encoding with an additional checksum. The checksum
 /// is appended to the end of the base-58 encoding and consists of the first 4 bytes of
 /// the SHA256D hash of the value.
-
 /// Encodes `data` as a base58 string including the checksum.
 ///
 /// The checksum is the first four bytes of the sha256d of the data and is concatenated onto the end.
-pub fn encode_with_checksum(data: &Vec<u8>) -> String {
+pub fn encode_with_checksum(data: &[u8]) -> String {
     let mut checksum = Hash::sha256d(data).raw[0..4].to_vec();
-    let mut ck_data = data.clone();
+    let mut ck_data = data.to_owned();
     ck_data.append(&mut checksum);
     ck_data.to_base58()
 }
@@ -25,7 +24,7 @@ pub fn encode_with_checksum(data: &Vec<u8>) -> String {
 ///
 /// The checksum is the first four bytes of the sha256d of the data and is concatenated onto the end
 /// of the base58 encoding.
-pub fn decode_with_checksum(encoded: &String) -> Result<Vec<u8>> {
+pub fn decode_with_checksum(encoded: &str) -> Result<Vec<u8>> {
     let mut data = encoded.from_base58()?;
     let l = data.len();
     if l < 5 {

--- a/bsv/src/bitcoin/block.rs
+++ b/bsv/src/bitcoin/block.rs
@@ -123,9 +123,9 @@ mod tests {
         .expect("Failed to read test data file");
         let block = Block::new(Bytes::from(raw)).expect("Failed to create block");
         assert_eq!(block.num_tx, 910);
-        let mut tx_iter = block.tx_iter();
+        let tx_iter = block.tx_iter();
         let mut count = 0;
-        while let Some(_) = tx_iter.next() {
+        for _ in tx_iter {
             count += 1;
         }
         assert_eq!(count, 910);
@@ -150,7 +150,7 @@ mod tests {
     /// check the genesis blocks encoded
     #[test]
     fn check_genesis_blocks() {
-        for i in vec![Main, Test, Stn, Regtest] {
+        for i in [Main, Test, Stn, Regtest] {
             let genesis_block = Block::get_genesis(i).expect("Failed to get genesis block");
             let _genesis_block_hex: String = genesis_block.encode_hex();
             assert_eq!(

--- a/bsv/src/bitcoin/crypto.rs
+++ b/bsv/src/bitcoin/crypto.rs
@@ -58,7 +58,7 @@ impl PrivateKey {
     /// Returns a tuple of the private key and the blockchain for which the private
     /// key is intended. Note that the function can not distinguish between the
     /// non-production blockchains so it must return [KeyAddressKind].
-    pub fn from_wif(wif: &String) -> Result<(PrivateKey, KeyAddressKind)> {
+    pub fn from_wif(wif: &str) -> Result<(PrivateKey, KeyAddressKind)> {
         let data = base58ck::decode_with_checksum(wif)?;
 
         let _compressed = match data.len() {
@@ -194,13 +194,13 @@ mod tests {
     fn test_bincode() {
         let privkey = PrivateKey::generate();
         let config = bincode::config::legacy();
-        let e = bincode::serde::encode_to_vec(&privkey, config).expect("Failed to encode privkey");
+        let e = bincode::serde::encode_to_vec(privkey, config).expect("Failed to encode privkey");
         let (d, _) =
             bincode::serde::decode_from_slice(&e, config).expect("Failed to decode privkey");
         assert_eq!(privkey, d);
 
         let pubkey = PublicKey::from(&privkey);
-        let e = bincode::serde::encode_to_vec(&pubkey, config).expect("Failed to encode pubkey");
+        let e = bincode::serde::encode_to_vec(pubkey, config).expect("Failed to encode pubkey");
         let (d, _) =
             bincode::serde::decode_from_slice(&e[..], config).expect("Failed to decode pubkey");
         assert_eq!(pubkey, d);

--- a/bsv/src/bitcoin/hash.rs
+++ b/bsv/src/bitcoin/hash.rs
@@ -78,7 +78,8 @@ impl Encodable for Hash {
     }
 
     fn to_binary(&self, buffer: &mut dyn BufMut) -> crate::Result<()> {
-        Ok(buffer.put_slice(&self.raw))
+        buffer.put_slice(&self.raw);
+        Ok(())
     }
 
     fn encoded_size(&self) -> u64 {

--- a/bsv/src/bitcoin/merkle.rs
+++ b/bsv/src/bitcoin/merkle.rs
@@ -137,7 +137,7 @@ pub fn verify_merkle_proof(
 
     for sibling in proof {
         // Determine if we're the left or right child
-        if current_index % 2 == 0 {
+        if current_index.is_multiple_of(2) {
             // We're the left child
             current_hash = hash_merkle_branches(&current_hash, sibling);
         } else {
@@ -169,7 +169,7 @@ pub fn calculate_partial_merkle_root(
     let mut _depth = 0;
     let mut level_size = total_tx_count;
     while level_size > 1 {
-        level_size = (level_size + 1) / 2;
+        level_size = level_size.div_ceil(2);
         _depth += 1;
     }
 

--- a/bsv/src/bitcoin/proptest_tests.rs
+++ b/bsv/src/bitcoin/proptest_tests.rs
@@ -31,7 +31,7 @@ mod tests {
 
     // Strategy for generating valid Bitcoin amounts (0 to 21 million BTC in satoshis)
     fn bitcoin_amount() -> impl Strategy<Value = u64> {
-        0u64..=21_000_000_00000000u64
+        0u64..=2_100_000_000_000_000_u64
     }
 
     // Strategy for generating transaction counts
@@ -138,7 +138,7 @@ mod tests {
             }
 
             // Add a number operation based on value
-            if num_value >= 1 && num_value <= 16 {
+            if (1..=16).contains(&num_value) {
                 use crate::bitcoin::script::Operation::*;
                 let op = match num_value {
                     1 => OP_1,
@@ -226,7 +226,7 @@ mod tests {
             use secp256k1::SecretKey;
 
             // Skip if the seed doesn't create a valid private key
-            if let Ok(secret_key) = SecretKey::from_slice(&seed) {
+            if let Ok(secret_key) = SecretKey::from_byte_array(seed) {
                 let privkey = PrivateKey::new(secret_key);
                 let pubkey1 = PublicKey::from(&privkey);
                 let pubkey2 = PublicKey::from(&privkey);

--- a/bsv/src/bitcoin/rules.rs
+++ b/bsv/src/bitcoin/rules.rs
@@ -89,10 +89,10 @@ pub fn MAX_MULTISIG_KEYS(policy: bool) -> u64 {
 }
 
 /// Configurable Consensus Rule - max memory used by stacks - default = 200MB - [link](https://github.com/bitcoin-sv-specs/protocol/blob/master/updates/genesis-spec.md#stack-memory-usage-consensus-rule)
-const CRULE_MAX_STACK_MEM: AtomicU64 = AtomicU64::new(200_000_000);
+static CRULE_MAX_STACK_MEM: AtomicU64 = AtomicU64::new(200_000_000);
 
 /// Policy - max memory used by stacks - default = 100MB - [link](https://github.com/bitcoin-sv-specs/protocol/blob/master/updates/genesis-spec.md#stack-memory-usage-policy)
-const POLICY_MAX_STACK_MEM: AtomicU64 = AtomicU64::new(100_000_000);
+static POLICY_MAX_STACK_MEM: AtomicU64 = AtomicU64::new(100_000_000);
 
 /// Get the policy or consensus rule value of the maximum memory used by the stacks.
 ///
@@ -106,7 +106,7 @@ pub fn MAX_STACK_MEM(policy: bool) -> u64 {
 }
 
 /// Policy - transaction evaluation timeout - default 1s = 1000 ms - [link](https://github.com/bitcoin-sv-specs/protocol/blob/master/updates/genesis-spec.md#transaction-evaluation-timeout)
-const POLICY_TX_EVAL_TIMEOUT_MS: AtomicU64 = AtomicU64::new(1_000);
+static POLICY_TX_EVAL_TIMEOUT_MS: AtomicU64 = AtomicU64::new(1_000);
 
 /// Get the policy value of the timeout for evaluating a transaction.
 pub fn TX_EVALE_TIMEOUT_MS() -> u64 {

--- a/bsv/src/bitcoin/script/byte_seq.rs
+++ b/bsv/src/bitcoin/script/byte_seq.rs
@@ -27,6 +27,11 @@ impl ByteSequence {
         self.raw.len()
     }
 
+    /// Check if the byte sequence is empty.
+    pub fn is_empty(&self) -> bool {
+        self.raw.is_empty()
+    }
+
     /// Can the byte sequence represent a small number (i64)?
     pub fn is_small_num(&self) -> bool {
         self.len() <= 8

--- a/bsv/src/bitcoin/script/interpreter.rs
+++ b/bsv/src/bitcoin/script/interpreter.rs
@@ -34,6 +34,12 @@ pub struct ScriptInterpreter {
     pub(crate) op_count: usize,
 }
 
+impl Default for ScriptInterpreter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ScriptInterpreter {
     pub fn new() -> Self {
         Self {
@@ -461,7 +467,7 @@ impl ScriptInterpreter {
                 let sha_result = sha_hasher.finalize();
 
                 let mut ripemd_hasher = Ripemd160::new();
-                RipemdDigest::update(&mut ripemd_hasher, &sha_result);
+                RipemdDigest::update(&mut ripemd_hasher, sha_result);
                 let result = ripemd_hasher.finalize();
                 self.push_bytes(Bytes::copy_from_slice(&result));
             }
@@ -642,7 +648,7 @@ fn bytes_to_int(bytes: &[u8]) -> Result<i64> {
 
     // Handle sign bit
     if bytes[bytes.len() - 1] & 0x80 != 0 {
-        result &= !((0x80 as i64) << (8 * (bytes.len() - 1)));
+        result &= !(0x80_i64 << (8 * (bytes.len() - 1)));
         result = -result;
     }
 

--- a/bsv/src/bitcoin/script/signature.rs
+++ b/bsv/src/bitcoin/script/signature.rs
@@ -225,12 +225,13 @@ pub fn remove_signature_from_script(script: &[u8], signature: &[u8]) -> Bytes {
             let mut found = false;
 
             // Check for direct push (OP_PUSH)
-            if script[i] == signature.len() as u8 && i + 1 + signature.len() <= script.len() {
-                if &script[i + 1..i + 1 + signature.len()] == signature {
-                    // Skip the push opcode and signature
-                    i += 1 + signature.len();
-                    found = true;
-                }
+            if script[i] == signature.len() as u8
+                && i + 1 + signature.len() <= script.len()
+                && &script[i + 1..i + 1 + signature.len()] == signature
+            {
+                // Skip the push opcode and signature
+                i += 1 + signature.len();
+                found = true;
             }
 
             if !found {
@@ -271,8 +272,8 @@ mod tests {
             Some(SigHashType::SingleAnyoneCanPay)
         );
 
-        assert!(SigHashType::All.anyone_can_pay() == false);
-        assert!(SigHashType::AllAnyoneCanPay.anyone_can_pay() == true);
+        assert!(!SigHashType::All.anyone_can_pay());
+        assert!(SigHashType::AllAnyoneCanPay.anyone_can_pay());
     }
 
     fn create_outpoint(tx_hash: &TxHash, index: u32) -> Outpoint {

--- a/bsv/src/bitcoin/tx.rs
+++ b/bsv/src/bitcoin/tx.rs
@@ -414,12 +414,12 @@ mod tests {
 
         // Should fail with a BadData error
         assert!(result.is_err());
-        match result.expect_err("Parsing should fail with validation error") {
-            Error::BadData(msg) => {
-                assert!(msg.contains("Too many transaction outputs"));
-                assert!(msg.contains(&excessive_outputs.to_string()));
-            }
-            _ => panic!("Expected BadData error for excessive outputs"),
+        if let Error::BadData(msg) = result.expect_err("Parsing should fail with validation error")
+        {
+            assert!(msg.contains("Too many transaction outputs"));
+            assert!(msg.contains(&excessive_outputs.to_string()));
+        } else {
+            panic!("Expected BadData error for excessive outputs")
         }
     }
 
@@ -447,12 +447,12 @@ mod tests {
         // Should fail due to insufficient data (not enough bytes for inputs),
         // but NOT due to validation error
         assert!(result.is_err());
-        match result.expect_err("Parsing should fail with validation error") {
-            Error::BadData(msg) => panic!(
+        if let Error::BadData(msg) = result.expect_err("Parsing should fail with validation error")
+        {
+            panic!(
                 "Should not fail validation with exactly MAX_TX_INPUTS: {}",
                 msg
-            ),
-            _ => {} // Expected to fail for other reasons (insufficient data)
+            )
         }
     }
 }

--- a/bsv/src/bitcoin/var_int.rs
+++ b/bsv/src/bitcoin/var_int.rs
@@ -41,7 +41,7 @@ pub fn varint_encode(buffer: &mut dyn BufMut, value: u64) -> crate::Result<()> {
         }
         _ => {
             buffer.put_u8(0xff);
-            buffer.put_u64_le(value as u64);
+            buffer.put_u64_le(value);
         }
     };
     Ok(())
@@ -56,18 +56,18 @@ mod tests {
     fn size() {
         assert_eq!(varint_size(0), 1);
         assert_eq!(varint_size(253), 3);
-        assert_eq!(varint_size(u16::max_value() as u64), 3);
-        assert_eq!(varint_size(u32::max_value() as u64), 5);
-        assert_eq!(varint_size(u64::max_value()), 9);
+        assert_eq!(varint_size(u16::MAX as u64), 3);
+        assert_eq!(varint_size(u32::MAX as u64), 5);
+        assert_eq!(varint_size(u64::MAX), 9);
     }
 
     #[test]
     fn write_read() {
         write_read_value(0);
         write_read_value(253);
-        write_read_value(u16::max_value() as u64);
-        write_read_value(u32::max_value() as u64);
-        write_read_value(u64::max_value());
+        write_read_value(u16::MAX as u64);
+        write_read_value(u32::MAX as u64);
+        write_read_value(u64::MAX);
     }
 
     fn write_read_value(n: u64) {

--- a/bsv/src/bitcoin/var_int_edge_tests.rs
+++ b/bsv/src/bitcoin/var_int_edge_tests.rs
@@ -299,7 +299,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42); // Deterministic for reproducibility
 
         for _ in 0..1000 {
-            let value = rng.gen::<u64>();
+            let value = rng.random::<u64>();
 
             let mut buf = BytesMut::new();
             varint_encode(&mut buf, value).unwrap();

--- a/bsv/src/lib.rs
+++ b/bsv/src/lib.rs
@@ -8,12 +8,12 @@
 //! other more established library, it is a re-write from ground level principles.
 //!
 //! * the library defines [BlockchainId] to distinguish between "mainnet", "testnet",
-//! etc, not "networks". The key feature that distinguishes these blockchains is the genesis block
-//! not the network. The P2P network is just a means for software to communicate, it does not define
-//! the blockchain.
+//!   etc, not "networks". The key feature that distinguishes these blockchains is the genesis block
+//!   not the network. The P2P network is just a means for software to communicate, it does not define
+//!   the blockchain.
 //!
 //! * the library will probably never support old versions of Bitcoin. Support for old versions is dead
-//! code and will be removed as quickly as possible.
+//!   code and will be removed as quickly as possible.
 //!
 //! [BlockchainId]: crate::bitcoin::BlockchainId
 

--- a/bsv/src/p2p/protocol.rs
+++ b/bsv/src/p2p/protocol.rs
@@ -123,6 +123,12 @@ pub struct MessageFramer {
     write_buffer: BytesMut,
 }
 
+impl Default for MessageFramer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MessageFramer {
     pub fn new() -> Self {
         Self {
@@ -201,7 +207,7 @@ mod tests {
         assert_eq!(version_msg.version, PROTOCOL_VERSION);
         assert_eq!(version_msg.services, Services::NETWORK);
         assert_eq!(version_msg.user_agent, "/rust-bitcoinsv:0.1.0/");
-        assert_eq!(version_msg.relay, true);
+        assert!(version_msg.relay);
 
         // Check timestamp is recent
         let now = SystemTime::now()
@@ -424,7 +430,7 @@ mod tests {
 
         assert_eq!(version_msg.services.0, 9); // NETWORK | WITNESS
         assert_eq!(version_msg.user_agent, "/custom-client:1.0/");
-        assert_eq!(version_msg.relay, false);
+        assert!(!version_msg.relay);
         assert_eq!(version_msg.start_height, 750000);
     }
 }


### PR DESCRIPTION
## Summary

This PR resolves all clippy warnings and improves code quality across the codebase:

### Key Changes

**Deprecated API Updates:**
- Replaced `SecretKey::from_slice` with `SecretKey::from_byte_array`
- Replaced `rng.gen()` with `rng.random()`
- Updated legacy numeric methods (`u16::max_value()` → `u16::MAX`, etc.)

**Idiomatic Rust Patterns:**
- Used `matches!` macro instead of verbose match expressions
- Converted single-arm `match` statements to `if let` patterns
- Replaced `while let` loops with `for` loops where appropriate
- Fixed range contains implementation to use `RangeInclusive::contains`

**API Improvements:**
- Changed function signatures from `&Vec<u8>` to `&[u8]` for better performance
- Changed `&String` to `&str` for string parameters
- Added missing `is_empty()` method to `ByteSequence` struct
- Changed `AtomicU64` constants to static items (correct for interior mutability)

**Code Cleanup:**
- Fixed documentation formatting (empty lines and list indentation)
- Removed needless borrows and unnecessary operations
- Used proper assertion patterns in tests (`assert!` vs `assert_eq!(x, true)`)
- Replaced `assert!(false)` with descriptive `panic!` messages

### Files Modified (17 files, +104/-78 lines)

- `bsv/src/bitcoin/address.rs`
- `bsv/src/bitcoin/base58ck.rs`
- `bsv/src/bitcoin/block.rs`
- `bsv/src/bitcoin/crypto.rs`
- `bsv/src/bitcoin/hash.rs`
- `bsv/src/bitcoin/merkle.rs`
- `bsv/src/bitcoin/proptest_tests.rs`
- `bsv/src/bitcoin/rules.rs`
- `bsv/src/bitcoin/script/byte_seq.rs`
- `bsv/src/bitcoin/script/interpreter.rs`
- `bsv/src/bitcoin/script/op.rs`
- `bsv/src/bitcoin/script/signature.rs`
- `bsv/src/bitcoin/tx.rs`
- `bsv/src/bitcoin/var_int.rs`
- `bsv/src/bitcoin/var_int_edge_tests.rs`
- `bsv/src/lib.rs`
- `bsv/src/p2p/protocol.rs`

## Test plan

- [x] All code formatted with `cargo fmt`
- [x] All clippy warnings resolved (verified with `cargo clippy`)
- [ ] CI tests pass (unit tests, property tests, build)
- [ ] No behavioral changes, only code quality improvements

All changes follow Rust best practices and idioms. The code is more maintainable and follows current Rust conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)